### PR TITLE
Fix naming collision with Yotpo Reviews module

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -2,7 +2,7 @@ const path = require("path");
 const { readdirSync } = require("fs");
 
 module.exports = function (moduleOptions) {
-  const filename = "nacelle-yotpo-plugin.js";
+  const filename = "nacelle-yotpo-loyalty-plugin.js";
   const options = {
     ...this.options.nacelle,
     ...moduleOptions,


### PR DESCRIPTION
Both of the Yotpo modules had the same name, so Nuxt was getting confused when both exist in the same project.